### PR TITLE
Deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,13 +54,13 @@ jobs:
         uses: thedoctor0/zip-release@4fb9e4ff72847dd3d1c111cf63834e353ed7cb3d
         with:
           type: 'zip'
-          filename: './release/the-board-files.zip'
+          filename: './the-board-files.zip'
           path: dist
       - name: Archive Release
         uses: thedoctor0/zip-release@4fb9e4ff72847dd3d1c111cf63834e353ed7cb3d
         with:
           type: 'tar'
-          filename: './release/the-board-files.tar.gz'
+          filename: './the-board-files.tar.gz'
           path: dist
             
       - name: Add CID to release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,8 @@ jobs:
             
       - name: Add CID to release
         run: 'echo ${{ steps.ipfs.outputs.HASH }} > ./release/ipfs.cid'
-
+      - name: a
+        run: ls release
       - name: Release
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,10 +78,10 @@ jobs:
           echo -e "\n\nIPFS CID: ${{ steps.ipfs.outputs.HASH }}" >> dist/changes.txt
           
           # use git tag's subject as release name
-          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tag)) || git describe --tag" >> $GITHUB_ENV
+          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tag) || git describe --tag)" >> $GITHUB_ENV
           
           # if the version number contains a - (for example v1.0.0-alpha1, v1.0.0-rc1, etc) the release is marked as a prerelease
-          echo "IS_PRERELEASE=$(! [[ $(git describe --tag) =~ "-" ]]; $?)" >> $GITHUB_ENV
+          echo "IS_PRERELEASE=$(! [[ $(git describe --tag) =~ "-" ]]) $?" >> $GITHUB_ENV
           
       # GitHub Release
       - name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,5 +76,4 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: the-board-files*,ipfs-cid.txt
-          bodyFile: changes.txt
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,25 +69,12 @@ jobs:
           path: dist
             
       - name: Add CID to release
-        run: 'echo ${{ steps.ipfs.outputs.HASH }} > ./ipfs.cid'
-        
-      # prepare release notes
-      - name: Release Notes
-        run: |
-          # release notes       
-          git tag -l --format='%(contents:body)' $(git describe --tags)} > changes.txt
-          
-          # ipfs cid to end of release notes
-          echo -e "\n\nIPFS CID: ${{ steps.ipfs.outputs.HASH }}" >> changes.txt
-          
-          # use git tag's subject as release name
-          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tags))" >> $GITHUB_ENV
+        run: 'echo ${{ steps.ipfs.outputs.HASH }} > ./ipfs-cid.txt'
 
       # GitHub Release
       - name: Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: the-board-files*,ipfs.cid
-          name: ${{env.NAME}}
+          artifacts: the-board-files*,ipfs-cid.txt
           bodyFile: changes.txt
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
+      # see: https://github.com/actions/checkout/issues/290
+      - name: Fetch Tags
+        run: git fetch --force --tags
+        
       # following 2 are github suggested caching for yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -79,9 +82,7 @@ jobs:
           
           # use git tag's subject as release name
           echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tags))" >> $GITHUB_ENV
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15
+
       # GitHub Release
       - name: Release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,13 +72,13 @@ jobs:
       - name: Release Notes
         run: |
           # release notes       
-          git tag -l --format='%(contents:body)' $(git describe --tag) > changes.txt
+          git tag -l --format='%(contents:body)' ${{github.ref}} > changes.txt
           
           # ipfs cid to end of release notes
           echo -e "\n\nIPFS CID: ${{ steps.ipfs.outputs.HASH }}" >> changes.txt
           
           # use git tag's subject as release name
-          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tag))" >> $GITHUB_ENV
+          echo "NAME=$(git tag -l --format='%(contents:subject)' ${{github.ref}})" >> $GITHUB_ENV
                     
       # GitHub Release
       - name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,9 @@ jobs:
         run: yarn install
       - name: build
         run: yarn build
-
+        
+      - name: gitignore on the target branch
+        run: cp .gitignore dist/
       # VARIOUS DEPLOYS
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,9 @@ jobs:
           # ipfs cid to end of release notes
           echo -e "\n\nIPFS CID: ${{ steps.ipfs.outputs.HASH }}" >> dist/changes.txt
           
+          # use git tag's subject as release name
+          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tag))" >> $GITHUB_ENV
+          
           # if the version number contains a - (for example v1.0.0-alpha1, v1.0.0-rc1, etc) the release is marked as a prerelease
           echo "IS_PRERELEASE=$([[ $(git describe --tag) =~ "-" ]])" >> $GITHUB_ENV
           
@@ -82,8 +85,9 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          file: |
+          files: |
             the-board-files*
             ipfs.cid
           prerelease: ${{env.IS_PRERELEASE}}
+          name: ${{env.NAME}}
           body_path: dist/changes.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,15 +73,15 @@ jobs:
         run: |
           # release notes       
           git tag -l --format='%(contents:body)' $(git describe --tags)} > changes.txt
-          cat changes.txt
           
           # ipfs cid to end of release notes
           echo -e "\n\nIPFS CID: ${{ steps.ipfs.outputs.HASH }}" >> changes.txt
           
           # use git tag's subject as release name
           echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tags))" >> $GITHUB_ENV
-          echo $(git describe --tags)
-                    
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 15
       # GitHub Release
       - name: Release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
           path: dist
             
       - name: Add CID to release
-        run: 'echo ${{ steps.ipfs.outputs.HASH } > ./release/ipfs.cid'
+        run: 'echo ${{ steps.ipfs.outputs.HASH }} > ./release/ipfs.cid'
 
       - name: Release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       # following 2 are github suggested caching for yarn
       - name: Get yarn cache directory path
@@ -28,12 +26,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      # build the app
       - name: install
         run: yarn install
       - name: build
         run: yarn build
 
-
+      # VARIOUS DEPLOYS
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
@@ -49,29 +48,42 @@ jobs:
           pinata-secret-api-key: ${{ secrets.PINATASECRETAPIKEY }}
           verbose: true
           remove-old: true
-      - name: Make release dir
-        run: mkdir release
+
+      # prepare release files
       - name: Archive Release
-        uses: thedoctor0/zip-release@master
+        uses: thedoctor0/zip-release@4fb9e4ff72847dd3d1c111cf63834e353ed7cb3d
         with:
           type: 'zip'
           filename: './release/the-board-files.zip'
           path: dist
       - name: Archive Release
-        uses: thedoctor0/zip-release@master
+        uses: thedoctor0/zip-release@4fb9e4ff72847dd3d1c111cf63834e353ed7cb3d
         with:
           type: 'tar'
           filename: './release/the-board-files.tar.gz'
           path: dist
             
       - name: Add CID to release
-        run: 'echo ${{ steps.ipfs.outputs.HASH }} > ./release/ipfs.cid'
-      - name: a
-        run: ls release
+        run: 'echo ${{ steps.ipfs.outputs.HASH }} > ./ipfs.cid'
+        
+      # prepare release notes
+      - name: Release Notes
+        run: |
+          # release notes       
+          git tag -l --format='%(contents:body)' $(git describe --tag) > dist/changes.txt
+          
+          # ipfs cid to end of release notes
+          echo -e "\n\nIPFS CID: ${{ steps.ipfs.outputs.HASH }}" >> dist/changes.txt
+          
+          # if the version number contains a - (for example v1.0.0-alpha1, v1.0.0-rc1, etc) the release is marked as a prerelease
+          echo "IS_PRERELEASE=$([[ $(git describe --tag) =~ "-" ]])" >> $GITHUB_ENV
+          
+      # GitHub Release
       - name: Release
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: "release/"
-          tag: ${{ github.ref }}
-
+          file: |
+            the-board-files*
+            ipfs.cid
+          prerelease: ${{env.IS_PRERELEASE}}
+          body_path: dist/changes.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,13 +78,10 @@ jobs:
           echo -e "\n\nIPFS CID: ${{ steps.ipfs.outputs.HASH }}" >> dist/changes.txt
           
           # use git tag's subject as release name
-          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tag))" >> $GITHUB_ENV
+          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tag)) || git describe --tag" >> $GITHUB_ENV
           
           # if the version number contains a - (for example v1.0.0-alpha1, v1.0.0-rc1, etc) the release is marked as a prerelease
-          echo "IS_PRERELEASE=$([[ $(git describe --tag) =~ "-" ]])" >> $GITHUB_ENV
-          cat $GITHUB_ENV
-          echo $GITHUB_ENV
-          git describe --tag
+          echo "IS_PRERELEASE=$(! [[ $(git describe --tag) =~ "-" ]]; $?)" >> $GITHUB_ENV
           
       # GitHub Release
       - name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,11 +85,9 @@ jobs:
           
       # GitHub Release
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          files: |
-            the-board-files*
-            ipfs.cid
+          artifacts: the-board-files*,ipfs.cid
           prerelease: ${{env.IS_PRERELEASE}}
           name: ${{env.NAME}}
-          body_path: dist/changes.txt
+          bodyFile: dist/changes.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,23 +72,19 @@ jobs:
       - name: Release Notes
         run: |
           # release notes       
-          git tag -l --format='%(contents:body)' $(git describe --tag) > dist/changes.txt
+          git tag -l --format='%(contents:body)' $(git describe --tag) > changes.txt
           
           # ipfs cid to end of release notes
-          echo -e "\n\nIPFS CID: ${{ steps.ipfs.outputs.HASH }}" >> dist/changes.txt
+          echo -e "\n\nIPFS CID: ${{ steps.ipfs.outputs.HASH }}" >> changes.txt
           
           # use git tag's subject as release name
-          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tag) && git describe --tag)" >> $GITHUB_ENV
-          
-          # if the version number contains a - (for example v1.0.0-alpha1, v1.0.0-rc1, etc) the release is marked as a prerelease
-          echo "IS_PRERELEASE=$(! [[ $(git describe --tag) =~ "-" ]]) $?" >> $GITHUB_ENV
-          
+          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tag))" >> $GITHUB_ENV
+                    
       # GitHub Release
       - name: Release
         uses: ncipollo/release-action@v1
         with:
           artifacts: the-board-files*,ipfs.cid
-          prerelease: ${{env.IS_PRERELEASE}}
           name: ${{env.NAME}}
-          bodyFile: dist/changes.txt
+          bodyFile: changes.txt
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+name: Build and release
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # following 2 are github suggested caching for yarn
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: install
+        run: yarn install
+      - name: build
+        run: yarn build
+
+      - name: Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: "dist/"
+          tag: ${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,15 +33,44 @@ jobs:
       - name: build
         run: yarn build
 
-      - name: Release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: "dist/"
-          tag: ${{ github.ref }}
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: pages # The branch the action should deploy to.
           folder: dist # The folder the action should deploy.
+      - name: Add to IPFS
+        id: ipfs
+        uses: anantaramdas/ipfs-pinata-deploy-action@v1.6.4 
+        with:
+          pin-name: 'theboard'
+          path: './dist'
+          pinata-api-key: ${{ secrets.PINATAAPIKEY }}
+          pinata-secret-api-key: ${{ secrets.PINATASECRETAPIKEY }}
+          verbose: true
+          remove-old: true
+      - name: Make release dir
+        run: mkdir release
+      - name: Archive Release
+        uses: thedoctor0/zip-release@master
+        with:
+          type: 'zip'
+          filename: './release/the-board-files.zip'
+          path: dist
+      - name: Archive Release
+        uses: thedoctor0/zip-release@master
+        with:
+          type: 'tar'
+          filename: './release/the-board-files.tar.gz'
+          path: dist
+            
+      - name: Add CID to release
+        run: 'echo ${{ steps.ipfs.outputs.HASH } > ./release/ipfs.cid'
+
+      - name: Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: "release/"
+          tag: ${{ github.ref }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,3 +39,9 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: "dist/"
           tag: ${{ github.ref }}
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: pages # The branch the action should deploy to.
+          folder: dist # The folder the action should deploy.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       # following 2 are github suggested caching for yarn
       - name: Get yarn cache directory path

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           branch: pages # The branch the action should deploy to.
           folder: dist # The folder the action should deploy.
+        if: ${{ !contains(github.ref, "-") }} # not prerelease
+          
       - name: Add to IPFS
         id: ipfs
         uses: anantaramdas/ipfs-pinata-deploy-action@v1.6.4 
@@ -53,6 +55,7 @@ jobs:
           pinata-secret-api-key: ${{ secrets.PINATASECRETAPIKEY }}
           verbose: true
           remove-old: true
+        if: ${{ !contains(github.ref, "-") }} # not prerelease
 
       # prepare release files
       - name: Archive Release
@@ -70,10 +73,12 @@ jobs:
             
       - name: Add CID to release
         run: 'echo ${{ steps.ipfs.outputs.HASH }} > ./ipfs-cid.txt'
+        if: ${{ !contains(github.ref, "-") }} # not prerelease
 
       # GitHub Release
       - name: Release
         uses: ncipollo/release-action@v1
         with:
           artifacts: the-board-files*,ipfs-cid.txt
+          prerelease: ${{ contains(github.ref, "-") }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,13 +72,15 @@ jobs:
       - name: Release Notes
         run: |
           # release notes       
-          git tag -l --format='%(contents:body)' ${{github.ref}} > changes.txt
+          git tag -l --format='%(contents:body)' $(git describe --tags)} > changes.txt
+          cat changes.txt
           
           # ipfs cid to end of release notes
           echo -e "\n\nIPFS CID: ${{ steps.ipfs.outputs.HASH }}" >> changes.txt
           
           # use git tag's subject as release name
-          echo "NAME=$(git tag -l --format='%(contents:subject)' ${{github.ref}})" >> $GITHUB_ENV
+          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tags))" >> $GITHUB_ENV
+          echo $(git describe --tags)
                     
       # GitHub Release
       - name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           branch: pages # The branch the action should deploy to.
           folder: dist # The folder the action should deploy.
-        if: ${{ !contains(github.ref, "-") }} # not prerelease
+        if: ${{ !contains(github.ref, '-') }} # not prerelease
           
       - name: Add to IPFS
         id: ipfs
@@ -55,7 +55,7 @@ jobs:
           pinata-secret-api-key: ${{ secrets.PINATASECRETAPIKEY }}
           verbose: true
           remove-old: true
-        if: ${{ !contains(github.ref, "-") }} # not prerelease
+        if: ${{ !contains(github.ref, '-') }} # not prerelease
 
       # prepare release files
       - name: Archive Release
@@ -73,12 +73,12 @@ jobs:
             
       - name: Add CID to release
         run: 'echo ${{ steps.ipfs.outputs.HASH }} > ./ipfs-cid.txt'
-        if: ${{ !contains(github.ref, "-") }} # not prerelease
+        if: ${{ !contains(github.ref, '-') }} # not prerelease
 
       # GitHub Release
       - name: Release
         uses: ncipollo/release-action@v1
         with:
           artifacts: the-board-files*,ipfs-cid.txt
-          prerelease: ${{ contains(github.ref, "-") }}
+          prerelease: ${{ contains(github.ref, '-') }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,9 @@ jobs:
           
           # if the version number contains a - (for example v1.0.0-alpha1, v1.0.0-rc1, etc) the release is marked as a prerelease
           echo "IS_PRERELEASE=$([[ $(git describe --tag) =~ "-" ]])" >> $GITHUB_ENV
+          cat $GITHUB_ENV
+          echo $GITHUB_ENV
+          git describe --tag
           
       # GitHub Release
       - name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
           echo -e "\n\nIPFS CID: ${{ steps.ipfs.outputs.HASH }}" >> dist/changes.txt
           
           # use git tag's subject as release name
-          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tag) || git describe --tag)" >> $GITHUB_ENV
+          echo "NAME=$(git tag -l --format='%(contents:subject)' $(git describe --tag) && git describe --tag)" >> $GITHUB_ENV
           
           # if the version number contains a - (for example v1.0.0-alpha1, v1.0.0-rc1, etc) the release is marked as a prerelease
           echo "IS_PRERELEASE=$(! [[ $(git describe --tag) =~ "-" ]]) $?" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,3 +91,4 @@ jobs:
           prerelease: ${{env.IS_PRERELEASE}}
           name: ${{env.NAME}}
           bodyFile: dist/changes.txt
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+on: 
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - "**"
+    tags:
+      - "!v**"
+  
+
+name: Build test
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: run tests
+        run: yarn run test
+      - uses: actions/upload-artifact@v2
+        with:
+          name: builds
+          path: up-rewrite
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,11 @@ jobs:
       - name: install files
         run: yarn install
       - name: run tests
+        run: yarn build
+      - name: run tests
         run: yarn run test
       - uses: actions/upload-artifact@v2
         with:
           name: builds
-          path: up-rewrite
+          path: dist/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # following 2 are github suggested caching for yarn
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: install files
+        run: yarn install
       - name: run tests
         run: yarn run test
       - uses: actions/upload-artifact@v2

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.0",
   "description": "A Whiteboard using the matrix protocol for collaboration and cloud storage",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"Error: no test specified\" && exit 0",
     "build": "webpack --config webpack.prod.js",
     "start": "webpack serve --config webpack.dev.js --open"
   },


### PR DESCRIPTION
As previously discussed in the Matrix room, I have this deployment thing. ATM it deploys to both IPFS and GH Pages, though IPFS hosting won't be useful to the project directly unless there's a domain. But, other people can access it from IPFS, so I don't know if you want to keep that feature. 

Apart from that, on a git tag, this will create a release and output zip and tar.gz files for anyone self-hosting the frontend. It also builds and tests every pull request. The deployment to GH Pages and IPFS only happens when there's no "-" in the git tag. For example, v1.0.0-alpha1 won't trigger a deployment, whereas v1.0.0 will.

Also, if accepted, these changes will need to be `Squash and Merge`d because there are too many commits. @toger5 any feedback on how you would want this to work? I know this wasn't discussed this extensively in the Matrix room, I just designed something that seemed appropriate and think could help.